### PR TITLE
Fix deprecated warnings after Prisma update

### DIFF
--- a/src/modules/auth/services/auth.service.ts
+++ b/src/modules/auth/services/auth.service.ts
@@ -55,7 +55,7 @@ export class AuthService {
   }
 
   async login({ email, password }: SigninInput): Promise<Token> {
-    const user = await this.prisma.user.findOne({ where: { email } })
+    const user = await this.prisma.user.findUnique({ where: { email } })
 
     if (!user) {
       throw new NotFoundException(`No user found with email ${email}`)
@@ -76,12 +76,12 @@ export class AuthService {
   }
 
   validateUser(userId: string): Promise<User> {
-    return this.prisma.user.findOne({ where: { id: userId } })
+    return this.prisma.user.findUnique({ where: { id: userId } })
   }
 
   getUserFromToken(token: string): Promise<User> {
     const id = this.jwtService.decode(token)['userId']
-    return this.prisma.user.findOne({ where: { id } })
+    return this.prisma.user.findUnique({ where: { id } })
   }
 
   generateToken(payload: Record<string, unknown>): Token {

--- a/src/modules/car/car.service.ts
+++ b/src/modules/car/car.service.ts
@@ -1,14 +1,10 @@
 import { Injectable } from '@nestjs/common'
-import {
-  Car,
-  CarWhereUniqueInput,
-  PrismaClientKnownRequestError
-} from '@prisma/client'
+import { Prisma, PrismaClientKnownRequestError } from '@prisma/client'
 import { UserInputError, ValidationError } from 'apollo-server-express'
 
 import { PrismaService } from '../../services'
 import { CreateCarInput, CarFilterArgs } from './dto'
-import { FavoriteCar } from './models'
+import { Car } from './models'
 import {
   buildCarFilterOptionsQuery,
   findOrCreateManufacturer,
@@ -26,8 +22,8 @@ interface CustomPrismaError extends PrismaClientKnownRequestError {
 export class CarService {
   constructor(private readonly prisma: PrismaService) {}
 
-  async car(carWhereUniqueInput: CarWhereUniqueInput): Promise<Car> {
-    return this.prisma.car.findOne({
+  async car(carWhereUniqueInput: Prisma.CarWhereUniqueInput): Promise<Car> {
+    return this.prisma.car.findUnique({
       where: carWhereUniqueInput,
       include: {
         manufacturer: true,

--- a/src/modules/car/queries/car_filter.query.ts
+++ b/src/modules/car/queries/car_filter.query.ts
@@ -1,8 +1,4 @@
-import {
-  CarSpecificationWhereInput,
-  CarWhereInput,
-  Enumerable
-} from '@prisma/client'
+import { Prisma, Enumerable } from '@prisma/client'
 
 import { CarFilterArgs } from '../dto'
 
@@ -15,7 +11,7 @@ export const buildCarFilterOptionsQuery = ({
   maxDailyRate,
   minDailyRate
 }: CarFilterArgs) => {
-  const name: Enumerable<CarWhereInput> = fullName
+  const name: Enumerable<Prisma.CarWhereInput> = fullName
     ? {
         OR: [
           {
@@ -36,7 +32,7 @@ export const buildCarFilterOptionsQuery = ({
       }
     : {}
 
-  const value: CarWhereInput =
+  const value: Prisma.CarWhereInput =
     maxDailyRate || minDailyRate
       ? {
           dailyRate: {
@@ -46,7 +42,7 @@ export const buildCarFilterOptionsQuery = ({
         }
       : {}
 
-  const fuelTypeSpecFilter: CarSpecificationWhereInput = fuelType
+  const fuelTypeSpecFilter: Prisma.CarSpecificationWhereInput = fuelType
     ? {
         specification: {
           name: 'FuelType'
@@ -55,7 +51,7 @@ export const buildCarFilterOptionsQuery = ({
       }
     : {}
 
-  const transmissionSpecFilter: CarSpecificationWhereInput = transmission
+  const transmissionSpecFilter: Prisma.CarSpecificationWhereInput = transmission
     ? {
         specification: {
           name: 'Transmission'
@@ -64,7 +60,7 @@ export const buildCarFilterOptionsQuery = ({
       }
     : {}
 
-  const specifications: CarWhereInput =
+  const specifications: Prisma.CarWhereInput =
     transmission && fuelType
       ? {
           AND: [
@@ -89,7 +85,7 @@ export const buildCarFilterOptionsQuery = ({
           }
         }
 
-  const availability: CarWhereInput =
+  const availability: Prisma.CarWhereInput =
     fromDate && toDate
       ? {
           Rental: {

--- a/src/modules/car/resolvers/car.resolver.ts
+++ b/src/modules/car/resolvers/car.resolver.ts
@@ -39,7 +39,7 @@ export class CarResolver {
   @ResolveField('manufacturer')
   async manufacturer(@Parent() { id }: Car) {
     return await this.prisma.car
-      .findOne({
+      .findUnique({
         where: { id }
       })
       .manufacturer()
@@ -48,7 +48,7 @@ export class CarResolver {
   @ResolveField('specifications')
   async specifications(@Parent() { id }: Car) {
     return await this.prisma.car
-      .findOne({
+      .findUnique({
         where: { id }
       })
       .specifications()
@@ -57,7 +57,7 @@ export class CarResolver {
   @ResolveField('photo')
   async photo(@Parent() { id }: Car) {
     return await this.prisma.car
-      .findOne({
+      .findUnique({
         where: { id }
       })
       .photo()
@@ -66,7 +66,7 @@ export class CarResolver {
   @ResolveField('fullName')
   async fullName(@Parent() car: Car) {
     const manufacturer = await this.prisma.car
-      .findOne({
+      .findUnique({
         where: {
           id: car.id
         }

--- a/src/modules/car/resolvers/car_specification.resolver.ts
+++ b/src/modules/car/resolvers/car_specification.resolver.ts
@@ -10,7 +10,7 @@ export class CarSpecificationResolver {
   @ResolveField('specification')
   async specification(@Parent() { id }: CarSpecification) {
     return await this.prisma.carSpecification
-      .findOne({
+      .findUnique({
         where: { id }
       })
       .specification()

--- a/src/modules/rental/rental.resolver.ts
+++ b/src/modules/rental/rental.resolver.ts
@@ -8,7 +8,7 @@ import {
 } from '@nestjs/graphql'
 import { PrismaService } from 'src/services'
 
-import { CreateRentalInput } from './dto/create_rental.input'
+import { CreateRentalInput } from './dto'
 import { Rental } from './rental.model'
 import { RentalService } from './rental.service'
 
@@ -32,7 +32,7 @@ export class RentalResolver {
   @ResolveField('user')
   async user(@Parent() rental: Rental) {
     return await this.prisma.rental
-      .findOne({
+      .findUnique({
         where: {
           id: rental.id
         }
@@ -43,7 +43,7 @@ export class RentalResolver {
   @ResolveField('car')
   async car(@Parent() rental: Rental) {
     return await this.prisma.rental
-      .findOne({
+      .findUnique({
         where: {
           id: rental.id
         }

--- a/src/modules/user/user.resolver.ts
+++ b/src/modules/user/user.resolver.ts
@@ -56,7 +56,7 @@ export class UserResolver {
   @ResolveField('avatar')
   async avatar(@Parent() user: User) {
     return this.prisma.user
-      .findOne({
+      .findUnique({
         where: {
           id: user.id
         }

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -1,10 +1,5 @@
 import { BadRequestException, Injectable } from '@nestjs/common'
-import {
-  User,
-  UserOrderByInput,
-  UserWhereInput,
-  UserWhereUniqueInput
-} from '@prisma/client'
+import { User, Prisma } from '@prisma/client'
 
 import { PrismaService } from '../../services/prisma.service'
 import { PasswordService } from '../auth/services/password.service'
@@ -17,8 +12,8 @@ export class UserService {
     private passwordService: PasswordService
   ) {}
 
-  async user(userWhereUniqueInput: UserWhereUniqueInput): Promise<User> {
-    return this.prisma.user.findOne({
+  async user(userWhereUniqueInput: Prisma.UserWhereUniqueInput): Promise<User> {
+    return this.prisma.user.findUnique({
       where: userWhereUniqueInput
     })
   }
@@ -26,9 +21,9 @@ export class UserService {
   async users(params: {
     skip?: number
     take?: number
-    cursor?: UserWhereUniqueInput
-    where?: UserWhereInput
-    orderBy?: UserOrderByInput
+    cursor?: Prisma.UserWhereUniqueInput
+    where?: Prisma.UserWhereInput
+    orderBy?: Prisma.UserOrderByInput
   }): Promise<User[]> {
     const { skip, take, cursor, where, orderBy } = params
     return this.prisma.user.findMany({
@@ -75,7 +70,7 @@ export class UserService {
     })
   }
 
-  async deleteUser(where: UserWhereUniqueInput): Promise<User> {
+  async deleteUser(where: Prisma.UserWhereUniqueInput): Promise<User> {
     return this.prisma.user.delete({
       where
     })


### PR DESCRIPTION
findOne -> findUnique
Inputs are now imported from Prisma object from @prisma/client